### PR TITLE
Removes @available on enum for Swift 5.5 compatibility

### DIFF
--- a/Sources/VideoSettings.Codec.swift
+++ b/Sources/VideoSettings.Codec.swift
@@ -73,7 +73,6 @@ public extension VideoSettings {
       ))
     }
 
-    @available(iOS 13.0, *)
     case hevcWithAlpha(_ compressionProperties: HEVCCompressionProperties)
 
     public static func h264(


### PR DESCRIPTION
The use of `@availability` on enum cases with values were removed in  https://github.com/apple/swift/commit/511ada4a50b9dd16a389b1aa9c1069e8e3f49046

There are already guards in other places to prevent using this in versions less than iOS13,
so this PR just removes the annotation. 
